### PR TITLE
add container build dependencies explicitly branch-v2.37.0-p1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/sys v0.9.0 // indirect
 	golang.org/x/text v0.10.0 // indirect
+	golang.org/x/tools v0.8.1-0.20230428195545-5283a0178901 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230530153820-e85fd2cbaebc // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc // indirect


### PR DESCRIPTION
This pr adds dependency golang.org/x/tools explicitly which is required for build for branch v2.37.0-p1