### PR TITLE
chore(deps): bump golang image from 1.22.5-alpine3.20 to 1.23.8-alpine3.20, and golangci-lint from 1.56.2 to 1.64.8, mysql from 5.7 to 8.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
       mysql:
-        image: mysql:5.7
+        image: mysql:8.4
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: dex
@@ -40,7 +40,7 @@ jobs:
         options: --health-cmd "mysql -proot -e \"show databases;\"" --health-interval 10s --health-timeout 5s --health-retries 5
 
       mysql-ent:
-        image: mysql:5.7
+        image: mysql:8.4
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: dex

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,6 @@ linters:
         - depguard
         - dogsled
         - exhaustive
-        - exportloopref
         - gci
         - gochecknoinits
         - gocritic

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=alpine
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.4.0@sha256:0cd3f05c72d6c9b038eb135f91376ee1169ef3a330d34e418e65e2a5c2e9c0d4 AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.22.5-alpine3.20@sha256:0d3653dd6f35159ec6e3d10263a42372f6f194c3dea0b35235d72aabde86486e AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.8-alpine3.20@sha256:7155e5b534ac02fb85191c51d64f727060a11ae987899f2b60c109c93f2c4777 AS builder
 
 COPY --from=xx / /
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ export GOBIN=$(PWD)/bin
 LD_FLAGS="-w -X main.version=$(VERSION)"
 
 # Dependency versions
-GOLANGCI_VERSION   = 1.56.2
+GOLANGCI_VERSION   = 1.64.8
 GOTESTSUM_VERSION ?= 1.10.1
 
 PROTOC_VERSION             = 24.4

--- a/connector/saml/saml.go
+++ b/connector/saml/saml.go
@@ -467,7 +467,7 @@ func (p *provider) validateStatus(status *status) error {
 		if statusMessage != nil && statusMessage.Value != "" {
 			errorMessage += " -> " + statusMessage.Value
 		}
-		return fmt.Errorf(errorMessage)
+		return errors.New(errorMessage)
 	}
 	return nil
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
         # image: mariadb:10.5
         # image: mysql:5.6
         # image: mysql:8.0
-        image: mysql:5.7
+        image: mysql:8.4
         environment:
             MYSQL_DATABASE: dex
             MYSQL_USER: mysql

--- a/server/introspectionhandler.go
+++ b/server/introspectionhandler.go
@@ -170,7 +170,7 @@ func (s *Server) getTokenFromRequest(r *http.Request) (string, TokenTypeEnum, er
 		return "", 0, newIntrospectBadRequestError(fmt.Sprintf("HTTP method is \"%s\", expected \"POST\".", r.Method))
 	} else if err := r.ParseForm(); err != nil {
 		return "", 0, newIntrospectBadRequestError("Unable to parse HTTP body, make sure to send a properly formatted form request body.")
-	} else if r.PostForm == nil || len(r.PostForm) == 0 {
+	} else if len(r.PostForm) == 0 {
 		return "", 0, newIntrospectBadRequestError("The POST body can not be empty.")
 	} else if !r.PostForm.Has("token") {
 		return "", 0, newIntrospectBadRequestError("The POST body doesn't contain 'token' parameter.")


### PR DESCRIPTION
bump golang image to be consistent with the go version in go.mod. [1.23.8-alpine3.20](https://hub.docker.com/layers/library/golang/1.23.8-alpine3.20/images/sha256-4205bd1c300641450f5b429c029bd4b57ed2f0ad93146a1bbc7d6763dca77a44)

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
Please review if this is the right golang image. To minimize any potential impact, I chose -alpine3.20 instead of the newer -alpine3.21.