### PR TITLE
v2.39.1-p1: downgrade from go 1.23.8 to 1.23.6 to work with RHEL 8 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=alpine
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.4.0@sha256:0cd3f05c72d6c9b038eb135f91376ee1169ef3a330d34e418e65e2a5c2e9c0d4 AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.23.8-alpine3.20@sha256:7155e5b534ac02fb85191c51d64f727060a11ae987899f2b60c109c93f2c4777 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.6-alpine3.20@sha256:484906fa392c79201ee01325cb42c0414aa9ad836afacf49a0e98a69fd252f78 AS builder
 
 COPY --from=xx / /
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dexidp/dex
 
-go 1.23.8
+go 1.23.6
 
 require (
 	cloud.google.com/go/compute/metadata v0.5.0


### PR DESCRIPTION
With go 1.23.8, we're seeing errors when building with rhel_8_golang_1.23. So downgrade to 1.23.6.
```
go: go.mod requires go >= 1.23.8 (running go 1.23.6; GOTOOLCHAIN=local)
```
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
