### PR TITLE
chore(deps): Fix for including go mod dependencies required for go generate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,8 @@ require (
 	golang.org/x/exp v0.0.0-20221004215720-b9f4876ce741
 	golang.org/x/net v0.27.0
 	golang.org/x/oauth2 v0.29.0
+	golang.org/x/sync v0.10.0
+	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
 	google.golang.org/api v0.190.0
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
@@ -98,8 +100,6 @@ require (
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
-	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
-	golang.org/x/sync v0.10.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240725223205-93522f1f2a9f // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240730163845-b1a4ccb954bf // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,10 @@
+//go:build tools
+
+package main
+
+import (
+	_ "github.com/mattn/go-runewidth"
+	_ "github.com/olekukonko/tablewriter"
+	_ "golang.org/x/sync/syncmap"
+	_ "golang.org/x/tools/imports"
+)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Running go generate fails in hermetic builds, as the dependencies required for generating the source code is not available in go.mod file and hence tools like Cachito/Hermeto which prefetches dependencies do not work in an hermetic builds. To fix this, specifying the required dependencies in `tools.go` so that `go mod tidy` does not remove these dependencies and the dependencies are explicitly specified as dummy imports in `tools.go`.

#### What this PR does / why we need it
`go mod tidy` removes dependencies from `go.mod` file which is required for running `go generate` command to generate source codes. By having explicit build only dependencies specified in `tools.go`, this can be avoided.

#### Special notes for your reviewer
